### PR TITLE
Fix DNS, fix kubelet communication

### DIFF
--- a/tasks/k8s-base.yml
+++ b/tasks/k8s-base.yml
@@ -9,6 +9,20 @@
     - socat
     - ntp
 
+# https://github.com/kubernetes/kubernetes/issues/21613#issuecomment-343190401
+- name: enable required kernel modules on boot
+  lineinfile:
+    line: "br_netfilter"
+    path: /etc/modprobe.d/kubernetes.conf
+    create: true
+  become: true
+
+- name: enable required kernel modules
+  modprobe:
+    name: br_netfilter
+    state: present
+  become: true
+
 - name: get the current CNI plugins version
   command: cat /opt/cni/cni-plugins-version
   register: cni_plugins_current_version

--- a/templates/kube-apiserver.manifest.j2
+++ b/templates/kube-apiserver.manifest.j2
@@ -46,6 +46,7 @@ spec:
       --kubelet-client-certificate=/var/lib/kubernetes/kubernetes.pem
       --kubelet-client-key=/var/lib/kubernetes/kubernetes-key.pem
       --kubelet-https=true
+      --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
       --runtime-config=api/all
       --service-account-key-file=/var/lib/kubernetes/ca-key.pem
       --service-cluster-ip-range={{ k8s_cni_service_cidr }}

--- a/templates/kubelet.service.j2
+++ b/templates/kubelet.service.j2
@@ -1,3 +1,9 @@
+#jinja2:lstrip_blocks: True
+{% if system_interface == "default" %}
+  {% set bind_ip = hostvars[inventory_hostname]['ansible_default_ipv4']['address'] %}
+{% else %}
+  {% set bind_ip = hostvars[inventory_hostname]['ansible_' + system_interface]['ipv4']['address'] %}
+{% endif %}
 [Unit]
 Description=Kubernetes Kubelet
 Documentation=https://github.com/kubernetes/kubernetes
@@ -29,6 +35,7 @@ ExecStart=/usr/local/bin/kubelet \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% \
   --feature-gates=ExperimentalCriticalPodAnnotation=true \
+  --node-ip={{ bind_ip }} \
   --node-labels=kubernetes.io/role=master,node-role.kubernetes.io/master= \
   --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
   --v=2


### PR DESCRIPTION
This PR fixes some slight issues:

* When a pod on the same node as kubedns attempted to make a DNS query in cluster, it would fail. The br_netfilter module was enabled to resolve this: https://github.com/kubernetes/kubernetes/issues/21613#issuecomment-343190401
* The kubelet has been modified to use the IP of the interface provided by the system_interface variable
* The API server has been modified to use the InternalIP of a node instead of it's hostname to reach it, as this is more extendable