### PR TITLE
Include IP address in kubelet client certificate

### DIFF
--- a/tasks/pki.yml
+++ b/tasks/pki.yml
@@ -146,7 +146,7 @@
   when: consul_enable
 
 - name: generate Kubernetes API server certificate
-  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ k8s_apiserver_public_host }},{{ k8s_apiserver_internal_host }},{{ k8s_apiserver_cni_host }},{{ apiserver_master_hosts | join(',') }} -profile=kubernetes kubernetes-csr.json | cfssljson -bare kubernetes chdir={{ role_path }}/files"
+  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ k8s_apiserver_public_host }},{{ k8s_apiserver_internal_host }},{{ k8s_apiserver_cni_host }},{{ apiserver_master_hosts | join(',') }},{{ k8s_master_ips | join(',') }} -profile=kubernetes kubernetes-csr.json | cfssljson -bare kubernetes chdir={{ role_path }}/files"
   run_once: true
   when: >
     apiserver_cert_path_stat.stat.exists == False
@@ -210,12 +210,22 @@
     - "{{ client_cert_stats.results }}"
     - "{{ client_key_stats.results }}"
 
-- name: generate client certificate
-  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ item.0.item }} -profile=kubernetes {{ item.0.item }}-csr.json | cfssljson -bare {{ item.0.item }} chdir={{ files_path }}"
+- name: generate client certificate (default)
+  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ item.0.item }},{{ hostvars[item.0.item]['ansible_default_ipv4']['address'] }} -profile=kubernetes {{ item.0.item }}-csr.json | cfssljson -bare {{ item.0.item }} chdir={{ files_path }}"
   run_once: true
   when: >
-    item.0.stat.exists == False
-    or item.1.stat.exists == False
+    (system_interface == 'default') and
+    (item.0.stat.exists == False or item.1.stat.exists == False)
+  with_together:
+    - "{{ client_cert_stats.results }}"
+    - "{{ client_key_stats.results }}"
+
+- name: generate client certificate
+  local_action: "shell cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -hostname={{ item.0.item }},{{ hostvars[item.0.item]['ansible_' + system_interface]['ipv4']['address'] }} -profile=kubernetes {{ item.0.item }}-csr.json | cfssljson -bare {{ item.0.item }} chdir={{ files_path }}"
+  run_once: true
+  when: >
+    (system_interface != 'default') and
+    (item.0.stat.exists == False or item.1.stat.exists == False)
   with_together:
     - "{{ client_cert_stats.results }}"
     - "{{ client_key_stats.results }}"


### PR DESCRIPTION
This PR makes the generation of the kubelet client certificate use the IP address of the host. This prevents issues with retrieving logs for pods on the master.